### PR TITLE
Strict typing for push on Window_BattleLog

### DIFF
--- a/src/rpg_window/Window_BattleLog.d.ts
+++ b/src/rpg_window/Window_BattleLog.d.ts
@@ -29,16 +29,20 @@ declare class Window_BattleLog extends Window_Base {
     public setWaitMode(waitMode: string): void;
     public callNextMethod(): void;
     public isFastForward(): boolean;
+    
     /**
      * Adds a method and any accompanying parameters to the list of methods that
      * need to be called. The method needs to be a member of this object, and the
      * parameters must be applicable to the method.
-     * //TODO can we get any type safety on this?
      * 
      * @param methodName The name of a method to call.
      * @param args The arguments to pass to the method, if any.
      */
-    public push(methodName:string, ...args: any[]): void;
+    public push<K extends keyof this, F extends (...args: unknown[]) => unknown>(
+        methodName: K,
+        ...args: this[K] extends F ? Parameters<this[K]> : never
+    ): this[K] extends F ? void : never;
+   
     public clear(): void;
     public wait(): void;
     public waitForEffect(): void;


### PR DESCRIPTION
It's kinda wild, but works like a charm :) 

The only drawback I can think of is that it also accepts variable names on the `methodName` parameter, the best I could do to work around this was to return `never` in those cases, which should be enough. It's better than just a `string` anyway.

The autocomplete on VS Code works very well with the `args` param, btw /o/